### PR TITLE
handle arguments missing when interpreting

### DIFF
--- a/lib/message_format.rb
+++ b/lib/message_format.rb
@@ -6,12 +6,12 @@ require_relative 'message_format/interpreter'
 module MessageFormat
   class MessageFormat
 
-    def initialize ( pattern, locale=nil )
+    def initialize ( pattern, locale=nil, require_all_args=false)
       @locale = (locale || TwitterCldr.locale).to_sym
       @format = Interpreter.interpret(
         Parser.parse(pattern),
-        { :locale => @locale }
-      )
+        { :locale => @locale, :require_all_args => require_all_args },
+        )
     end
 
     def format ( args=nil )

--- a/lib/message_format/interpreter.rb
+++ b/lib/message_format/interpreter.rb
@@ -23,6 +23,14 @@ module MessageFormat
       else
         @locale = TwitterCldr.locale
       end
+      @require_all_args = !!options[:require_all_args]
+    end
+
+    def assert_arg_exists(args, id)
+      if @require_all_args && args[id].nil?
+        raise MissingArgError.new "Require #{id} in the arguments, which were #{args}"
+      end
+      return !args[id].nil?
     end
 
     def interpret ( elements )
@@ -62,26 +70,27 @@ module MessageFormat
       id = id.to_sym # actual arguments should always be keyed by symbols
 
       case type
-        when 'number'
-          interpret_number(id, offset, style)
-        when 'date', 'time'
-          interpret_date_time(id, type, style)
-        when 'plural', 'selectordinal'
-          offset = element[2]
-          options = element[3]
-          interpret_plural(id, type, offset, options)
-        when 'select'
-          interpret_select(id, style)
-        when 'spellout', 'ordinal', 'duration'
-          interpret_number(id, offset, type)
-        else
-          interpret_simple(id)
+      when 'number'
+        interpret_number(id, offset, style)
+      when 'date', 'time'
+        interpret_date_time(id, type, style)
+      when 'plural', 'selectordinal'
+        offset = element[2]
+        options = element[3]
+        interpret_plural(id, type, offset, options)
+      when 'select'
+        interpret_select(id, style)
+      when 'spellout', 'ordinal', 'duration'
+        interpret_number(id, offset, type)
+      else
+        interpret_simple(id)
       end
     end
 
     def interpret_number ( id, offset, style )
       locale = @locale
       lambda do |args|
+        return '' if !assert_arg_exists(args, id)
         number = TwitterCldr::Localized::LocalizedNumber.new(args[id] - offset, locale)
         if style == 'integer'
           number.to_decimal.to_s(:precision => 0)
@@ -102,6 +111,7 @@ module MessageFormat
     def interpret_date_time ( id, type, style='medium' )
       locale = @locale
       lambda do |args|
+        return '' if !assert_arg_exists(args, id)
         datetime = TwitterCldr::Localized::LocalizedDateTime.new(args[id], locale)
         datetime = type == 'date' ? datetime.to_date : datetime.to_time
         if style == 'medium'
@@ -128,13 +138,14 @@ module MessageFormat
       locale = @locale
       plural_type = type == 'selectordinal' ? :ordinal : :cardinal
       lambda do |args|
+        return '' if !assert_arg_exists(args, id)
         arg = args[id]
         exactSelector = ('=' + arg.to_s).to_sym
         keywordSelector = TwitterCldr::Formatters::Plurals::Rules.rule_for(arg - offset, locale, plural_type)
         func =
           options[exactSelector] ||
-          options[keywordSelector] ||
-          options[:other]
+            options[keywordSelector] ||
+            options[:other]
         func.call(args)
       end
     end
@@ -145,21 +156,27 @@ module MessageFormat
         options[key.to_sym] = interpret_subs(value, nil)
       end
       lambda do |args|
+        return '' if !assert_arg_exists(args, id)
         selector = args[id].to_sym
         func =
           options[selector] ||
-          options[:other]
+            options[:other]
         func.call(args)
       end
     end
 
     def interpret_simple ( id )
-      lambda { |args| args[id].to_s }
+      lambda do |args|
+        assert_arg_exists(args, id)
+        args[id].to_s
+      end
     end
 
     def self.interpret ( elements, options=nil )
       Interpreter.new(options).interpret(elements)
     end
 
+    class MissingArgError < RuntimeError
+    end
   end
 end

--- a/spec/message_format_spec.rb
+++ b/spec/message_format_spec.rb
@@ -61,7 +61,7 @@ describe MessageFormat do
             =1 {drove himself.}
          other {drove # people.}}'
       message = MessageFormat.new(pattern, 'en-US')
-          .format({ :takenDate => DateTime.now, :name => 'Bob', :numPeople => 5 })
+                             .format({ :takenDate => DateTime.now, :name => 'Bob', :numPeople => 5 })
 
       expect(message).to match(/^On \d\d?\/\d\d?\/\d{2,4} Bob drove 4 people.$/)
     end
@@ -106,13 +106,69 @@ describe MessageFormat do
          female {it\'s her turn}
           other {it\'s their turn}}'
       message = MessageFormat.new(pattern, 'en-US')
-          .format({ gender: 'female' })
+                             .format({ gender: 'female' })
 
       expect(message).to eql('it\'s her turn')
     end
 
     it 'should throw an error when args are expected and not passed' do
       expect { MessageFormat.new('{a}').format() }.to raise_error
+    end
+
+    it 'partially-missing args - formats numbers, dates, and times' do
+      pattern = '{ n, number } : { d, date, short } { d, time, short }'
+      message = MessageFormat.new(pattern, 'en-US').format({:n => 0})
+      expect(message).to eql('0 :  ')
+
+      expect{MessageFormat.new(pattern, 'en-US', true).format({:n => 0})}.to raise_error
+    end
+
+    it 'formats integer number' do
+      pattern = '{ n, number, integer }'
+      message = MessageFormat.new(pattern, 'en-US').format({})
+      expect(message).to eql('')
+
+      expect{MessageFormat.new(pattern, 'en-US', true).format({})}.to raise_error
+    end
+
+    it 'partially-missing args - handles plurals' do
+      pattern =
+        'On {takenDate, date, short} {name} {numPeople, plural, offset:1
+            =0 {didn\'t carpool.}
+            =1 {drove himself.}
+         other {drove # people.}}'
+      message = MessageFormat.new(pattern, 'en-US')
+                             .format({ :takenDate => DateTime.now, :name => 'Bob'})
+      expect(message).to match(/^On \d\d?\/\d\d?\/\d{2,4} Bob $/)
+
+      expect{MessageFormat.new(pattern, 'en-US', true).format({})}.to raise_error
+    end
+
+    it 'partially-missing args - handles selectordinals' do
+      pattern =
+        '{n, selectordinal,
+           one {#st}
+           two {#nd}
+           few {#rd}
+         other {#th}}'
+      expect(MessageFormat.new(pattern, 'en').format({})).to eql('')
+      expect{MessageFormat.new(pattern, 'en', true).format({})}.to raise_error
+    end
+
+    it 'partially-missing args - handle simple' do
+      expect { MessageFormat.new('{a}', nil, true).format({})}.to raise_error
+      expect(MessageFormat.new('{a}', nil).format({})).to eql('')
+    end
+
+    it 'partially-missing args - handle select' do
+      pattern =
+        '{ gender, select,
+           male {it\'s his turn}
+         female {it\'s her turn}
+          other {it\'s their turn}}'
+      expect { MessageFormat.new(pattern, 'en-US', true)
+                            .format({ some_other_arg: 'aaa' })}.to raise_error
+      expect(MessageFormat.new(pattern, 'en-US').format({})).to eql('')
     end
   end
 
@@ -124,16 +180,16 @@ describe MessageFormat do
             =1 {drove himself.}
          other {drove # people.}}'
       message = MessageFormat.format_message(pattern,
-        :takenDate => DateTime.now,
-        :name => 'Bob',
-        :numPeople => 5
+                                             :takenDate => DateTime.now,
+                                             :name => 'Bob',
+                                             :numPeople => 5
       )
       expect(message).to match(/^On \d\d?\/\d\d?\/\d{2,4} Bob drove 4 people.$/)
 
       message = MessageFormat::format_message(pattern,
-        :takenDate => DateTime.now,
-        :name => 'Bill',
-        :numPeople => 6
+                                              :takenDate => DateTime.now,
+                                              :name => 'Bill',
+                                              :numPeople => 6
       )
       expect(message).to match(/^On \d\d?\/\d\d?\/\d{2,4} Bill drove 5 people.$/)
     end


### PR DESCRIPTION
The MessageFormat gem does not currently well-handle the case of arguments missing. It will throw an error in the case where an argument object is not passed in at all, but won't detect if the argument object is empty, or if a subset of the arguments are missing.

This PR makes 2 major changes
- adds the feature to initialize MessageFormat so that it can optionally enforce that all arguments are missing.
- updates the interpreter code so that if an argument is missing AND we do not enforce that all arguments are required, then we still will format the string but will leave out the missing arguments

Tests
- added tests and ran them locally with `rspec` 
<img width="595" alt="Screen Shot 2022-07-20 at 3 26 06 PM" src="https://user-images.githubusercontent.com/10457592/180065438-4c48d672-ff29-4866-9f5a-e4629c5c673d.png">